### PR TITLE
feat: (gpt-1-sequence-classification) 92% accuracy on test set

### DIFF
--- a/src/models/gpt_1_sequence_classification/evaluate.ipynb
+++ b/src/models/gpt_1_sequence_classification/evaluate.ipynb
@@ -1,0 +1,371 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append(\n",
+    "    os.path.abspath(\n",
+    "        os.path.join(os.path.dirname(os.path.abspath(\"__file__\")), \"../../..\")\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from functools import partial\n",
+    "from textwrap import dedent\n",
+    "from typing import Dict, Literal\n",
+    "\n",
+    "from datasets import DatasetDict, load_dataset\n",
+    "from transformers import AutoModelForSequenceClassification, AutoTokenizer, DataCollatorWithPadding, EarlyStoppingCallback, Trainer, TrainingArguments\n",
+    "\n",
+    "from src.shared.config import settings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HF_GPT_ID = \"openai-gpt\"\n",
+    "FINETUNED_HF_GPT_ID = f\"{settings.hf_user_name}/{settings.gpt_1_sequence_classification}\"\n",
+    "\n",
+    "\n",
+    "def tokenizer_init():\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(HF_GPT_ID)\n",
+    "    tokenizer.add_special_tokens(\n",
+    "        {\"pad_token\": \"<pad>\"}\n",
+    "    )  # gpt-1 tokenizer lacks this by default\n",
+    "    return tokenizer\n",
+    "\n",
+    "\n",
+    "def model_init():\n",
+    "    tokenizer = tokenizer_init()\n",
+    "    model = AutoModelForSequenceClassification.from_pretrained(FINETUNED_HF_GPT_ID, num_labels=9)\n",
+    "    model.resize_token_embeddings(\n",
+    "        len(tokenizer), mean_resizing=False\n",
+    "    )  # extend the embedding layer to handle padding and eos tokens\n",
+    "    model.config.pad_token_id = tokenizer.pad_token_id\n",
+    "    return model.to(settings.device)\n",
+    "\n",
+    "\n",
+    "def format_dataset_row(\n",
+    "    row, unique_from_accounts: set, label_mapping: Dict[str, int]\n",
+    ") -> Dict[Literal[\"text\"], str]:\n",
+    "    row = dict(row)\n",
+    "    from_account = row.pop(\"from_account\")\n",
+    "    formatted = dedent(\n",
+    "    f\"\"\"\n",
+    "        <possible accounts>{', '.join(unique_from_accounts)}</possible accounts>\n",
+    "        <transaction>{json.dumps(row)}</transaction>\n",
+    "        which account did this transaction come from?\n",
+    "    \"\"\"\n",
+    "    ).strip()\n",
+    "    return {\"text\": formatted, \"labels\": label_mapping[from_account]}\n",
+    "\n",
+    "\n",
+    "def test_dataset_init(tokenizer) -> DatasetDict:\n",
+    "    dataset = load_dataset(f\"{settings.hf_user_name}/{settings.hf_dataset_repo_name}\")\n",
+    "\n",
+    "    unique_from_accounts = set(\n",
+    "        dataset[\"train\"][\"from_account\"] + dataset[\"test\"][\"from_account\"]\n",
+    "    )\n",
+    "    label_mapping = {account: idx for idx, account in enumerate(unique_from_accounts)}\n",
+    "    format_dataset_row_partial = partial(\n",
+    "        format_dataset_row,\n",
+    "        unique_from_accounts=unique_from_accounts,\n",
+    "        label_mapping=label_mapping,\n",
+    "    )\n",
+    "\n",
+    "    dataset[\"test\"] = dataset[\"test\"].map(format_dataset_row_partial)\n",
+    "    del dataset[\"train\"]\n",
+    "\n",
+    "    remove_columns = [\n",
+    "        \"amount\",\n",
+    "        \"month\",\n",
+    "        \"day\",\n",
+    "        \"year\",\n",
+    "        \"vendor\",\n",
+    "        \"from_account\",\n",
+    "        \"text\"\n",
+    "    ]\n",
+    "    dataset = dataset.map(\n",
+    "        lambda batch: tokenizer(batch[\"text\"]),\n",
+    "        batched=True,\n",
+    "        remove_columns=remove_columns,\n",
+    "    )\n",
+    "    dataset.set_format(\"pt\")\n",
+    "    return dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8ea4cf5a24b4f0d9f325bc08485df93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/1.22k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eff392800bb74cc0b4d08c43542e4504",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/466M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebf84a598a1a4f1ebd2d802df0443492",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a26816d0c3e4dd4b2f69a085140425a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.18181818181818182"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"/tmp/eval\",\n",
+    "    per_device_eval_batch_size=64,\n",
+    "    report_to=\"none\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model_init(),\n",
+    "    args=training_args,\n",
+    "    data_collator=DataCollatorWithPadding(tokenizer=tokenizer_init()),\n",
+    ")\n",
+    "\n",
+    "dataset = test_dataset_init(tokenizer_init())\n",
+    "\n",
+    "predictions = trainer.predict(dataset[\"test\"])\n",
+    "actual = predictions.label_ids\n",
+    "predictions = predictions.predictions.argmax(-1)\n",
+    "\n",
+    "accuracy = sum(1 for pred, act in zip(predictions, actual) if pred == act) / len(predictions)\n",
+    "accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
+       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<possible accounts>Assets:Discover:Main:Needs:Groceries, Assets:Discover:Main:Needs:Monthly, Assets:Discover:Main:Wants:Monthly, Assets:Discover:Main:Needs:Other, Assets:Discover:Travel, Assets:Discover:FutureWants, Assets:Discover:Main:Wants:Other, Assets:Discover:Main:Needs:Gas, Assets:Discover:Furniture</possible accounts>\n",
+      "<transaction>{\"amount\": 89.99, \"month\": 6, \"day\": 4, \"year\": 2023, \"vendor\": \"WALMART\"}</transaction>\n",
+      "which account did this transaction come from?\n",
+      "answer:\n",
+      "\n",
+      "Assets:Discover:Main:Needs:Groceries\n",
+      "\n",
+      "Assets:Discover:Main:Needs:Groceries\n"
+     ]
+    }
+   ],
+   "source": [
+    "example = dataset[\"test\"][\"text\"][21]\n",
+    "actual = dataset[\"test\"][\"from_account\"][21]\n",
+    "prediction = pipeline(example)\n",
+    "\n",
+    "print(example, actual, prediction, sep=\"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = model_init()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OpenAIGPTForSequenceClassification(\n",
+       "  (transformer): OpenAIGPTModel(\n",
+       "    (tokens_embed): Embedding(40479, 768)\n",
+       "    (positions_embed): Embedding(512, 768)\n",
+       "    (drop): Dropout(p=0.1, inplace=False)\n",
+       "    (h): ModuleList(\n",
+       "      (0-11): 12 x Block(\n",
+       "        (attn): Attention(\n",
+       "          (c_attn): Conv1D(nf=2304, nx=768)\n",
+       "          (c_proj): Conv1D(nf=768, nx=768)\n",
+       "          (attn_dropout): Dropout(p=0.1, inplace=False)\n",
+       "          (resid_dropout): Dropout(p=0.1, inplace=False)\n",
+       "        )\n",
+       "        (ln_1): LayerNorm((768,), eps=1e-05, elementwise_affine=True)\n",
+       "        (mlp): MLP(\n",
+       "          (c_fc): Conv1D(nf=3072, nx=768)\n",
+       "          (c_proj): Conv1D(nf=768, nx=3072)\n",
+       "          (act): NewGELUActivation()\n",
+       "          (dropout): Dropout(p=0.1, inplace=False)\n",
+       "        )\n",
+       "        (ln_2): LayerNorm((768,), eps=1e-05, elementwise_affine=True)\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (score): Linear(in_features=768, out_features=2, bias=False)\n",
+       ")"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/models/gpt_1_sequence_classification/evaluate.ipynb
+++ b/src/models/gpt_1_sequence_classification/evaluate.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,17 +18,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
     "from functools import partial\n",
     "from textwrap import dedent\n",
     "from typing import Dict, Literal\n",
     "\n",
-    "from datasets import DatasetDict, load_dataset\n",
-    "from transformers import AutoModelForSequenceClassification, AutoTokenizer, DataCollatorWithPadding, EarlyStoppingCallback, Trainer, TrainingArguments\n",
+    "from datasets import DatasetDict, load_dataset, Dataset\n",
+    "from transformers import AutoModelForSequenceClassification, AutoTokenizer, DataCollatorWithPadding, Trainer, TrainingArguments\n",
     "\n",
     "from src.shared.config import settings"
    ]
@@ -42,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,54 +59,53 @@
     "\n",
     "def model_init():\n",
     "    tokenizer = tokenizer_init()\n",
-    "    model = AutoModelForSequenceClassification.from_pretrained(FINETUNED_HF_GPT_ID, num_labels=9)\n",
+    "    model = AutoModelForSequenceClassification.from_pretrained(FINETUNED_HF_GPT_ID, num_labels=8)\n",
     "    model.resize_token_embeddings(\n",
     "        len(tokenizer), mean_resizing=False\n",
-    "    )  # extend the embedding layer to handle padding and eos tokens\n",
+    "    )  # extend the embedding layer to handle padding token\n",
     "    model.config.pad_token_id = tokenizer.pad_token_id\n",
     "    return model.to(settings.device)\n",
     "\n",
     "\n",
     "def format_dataset_row(\n",
-    "    row, unique_from_accounts: set, label_mapping: Dict[str, int]\n",
+    "    row, label_mapping: Dict[str, int]\n",
     ") -> Dict[Literal[\"text\"], str]:\n",
     "    row = dict(row)\n",
     "    from_account = row.pop(\"from_account\")\n",
     "    formatted = dedent(\n",
-    "    f\"\"\"\n",
-    "        <possible accounts>{', '.join(unique_from_accounts)}</possible accounts>\n",
-    "        <transaction>{json.dumps(row)}</transaction>\n",
-    "        which account did this transaction come from?\n",
-    "    \"\"\"\n",
+    "        f\"\"\"\n",
+    "        Transaction\n",
+    "        -----------\n",
+    "        Description: {row['description']}\n",
+    "        Amount: {row['amount']}\n",
+    "        Category: {row['category']} (Source: {row['category_source']})\n",
+    "        Transaction Date: {row['transaction_date']}\n",
+    "        Day of Week: {row['day_of_week']}\n",
+    "        Card: {row['card']}\n",
+    "\n",
+    "        Question: Which account initiated this transaction?\n",
+    "        Answer:\n",
+    "        \"\"\"\n",
     "    ).strip()\n",
     "    return {\"text\": formatted, \"labels\": label_mapping[from_account]}\n",
-    "\n",
     "\n",
     "def test_dataset_init(tokenizer) -> DatasetDict:\n",
     "    dataset = load_dataset(f\"{settings.hf_user_name}/{settings.hf_dataset_repo_name}\")\n",
     "\n",
-    "    unique_from_accounts = set(\n",
+    "    unique_from_accounts = sorted(set(\n",
     "        dataset[\"train\"][\"from_account\"] + dataset[\"test\"][\"from_account\"]\n",
-    "    )\n",
+    "    ))\n",
     "    label_mapping = {account: idx for idx, account in enumerate(unique_from_accounts)}\n",
+    "    print(f'label_mapping: {label_mapping}')\n",
     "    format_dataset_row_partial = partial(\n",
     "        format_dataset_row,\n",
-    "        unique_from_accounts=unique_from_accounts,\n",
     "        label_mapping=label_mapping,\n",
     "    )\n",
     "\n",
     "    dataset[\"test\"] = dataset[\"test\"].map(format_dataset_row_partial)\n",
     "    del dataset[\"train\"]\n",
     "\n",
-    "    remove_columns = [\n",
-    "        \"amount\",\n",
-    "        \"month\",\n",
-    "        \"day\",\n",
-    "        \"year\",\n",
-    "        \"vendor\",\n",
-    "        \"from_account\",\n",
-    "        \"text\"\n",
-    "    ]\n",
+    "    remove_columns = ['transaction_date', 'description', 'amount', 'category', 'category_source', 'card', 'day_of_week']\n",
     "    dataset = dataset.map(\n",
     "        lambda batch: tokenizer(batch[\"text\"]),\n",
     "        batched=True,\n",
@@ -126,64 +124,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e8ea4cf5a24b4f0d9f325bc08485df93",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/1.22k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eff392800bb74cc0b4d08c43542e4504",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/466M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ebf84a598a1a4f1ebd2d802df0443492",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a26816d0c3e4dd4b2f69a085140425a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "label_mapping: {'Assets:Discover:Furniture': 0, 'Assets:Discover:FutureWants': 1, 'Assets:Discover:Main:Needs:Gas': 2, 'Assets:Discover:Main:Needs:Groceries': 3, 'Assets:Discover:Main:Needs:Monthly': 4, 'Assets:Discover:Main:Needs:Other': 5, 'Assets:Discover:Main:Wants:Monthly': 6, 'Assets:Discover:Main:Wants:Other': 7}\n"
+     ]
     },
     {
      "data": {
@@ -198,10 +147,10 @@
     {
      "data": {
       "text/plain": [
-       "0.18181818181818182"
+       "0.927461139896373"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -223,10 +172,11 @@
     "\n",
     "predictions = trainer.predict(dataset[\"test\"])\n",
     "actual = predictions.label_ids\n",
-    "predictions = predictions.predictions.argmax(-1)\n",
+    "predicted = predictions.predictions.argmax(axis=-1)\n",
     "\n",
-    "accuracy = sum(1 for pred, act in zip(predictions, actual) if pred == act) / len(predictions)\n",
-    "accuracy"
+    "# Calculate accuracy using numpy for better performance\n",
+    "accuracy = (predicted == actual).mean()\n",
+    "accuracy.item()"
    ]
   },
   {
@@ -238,112 +188,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [],
       "text/plain": [
-       "array([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,\n",
-       "       5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])"
+       "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<possible accounts>Assets:Discover:Main:Needs:Groceries, Assets:Discover:Main:Needs:Monthly, Assets:Discover:Main:Wants:Monthly, Assets:Discover:Main:Needs:Other, Assets:Discover:Travel, Assets:Discover:FutureWants, Assets:Discover:Main:Wants:Other, Assets:Discover:Main:Needs:Gas, Assets:Discover:Furniture</possible accounts>\n",
-      "<transaction>{\"amount\": 89.99, \"month\": 6, \"day\": 4, \"year\": 2023, \"vendor\": \"WALMART\"}</transaction>\n",
-      "which account did this transaction come from?\n",
-      "answer:\n",
+      "Transaction\n",
+      "-----------\n",
+      "Description: O DONELL ACE HARDWARE DES MOINES IA\n",
+      "Amount: 23.19\n",
+      "Category: Home Improvement (Source: Discover)\n",
+      "Transaction Date: 2023-03-22\n",
+      "Day of Week: Wednesday\n",
+      "Card: Discover It Chrome\n",
       "\n",
-      "Assets:Discover:Main:Needs:Groceries\n",
+      "Question: Which account initiated this transaction?\n",
+      "Answer:\n",
       "\n",
-      "Assets:Discover:Main:Needs:Groceries\n"
+      "Assets:Discover:Main:Needs:Other\n",
+      "\n",
+      "Assets:Discover:Main:Needs:Other\n"
      ]
     }
    ],
    "source": [
-    "example = dataset[\"test\"][\"text\"][21]\n",
-    "actual = dataset[\"test\"][\"from_account\"][21]\n",
-    "prediction = pipeline(example)\n",
+    "instance = 0\n",
+    "example = dataset[\"test\"][instance]\n",
     "\n",
-    "print(example, actual, prediction, sep=\"\\n\\n\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = model_init()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OpenAIGPTForSequenceClassification(\n",
-       "  (transformer): OpenAIGPTModel(\n",
-       "    (tokens_embed): Embedding(40479, 768)\n",
-       "    (positions_embed): Embedding(512, 768)\n",
-       "    (drop): Dropout(p=0.1, inplace=False)\n",
-       "    (h): ModuleList(\n",
-       "      (0-11): 12 x Block(\n",
-       "        (attn): Attention(\n",
-       "          (c_attn): Conv1D(nf=2304, nx=768)\n",
-       "          (c_proj): Conv1D(nf=768, nx=768)\n",
-       "          (attn_dropout): Dropout(p=0.1, inplace=False)\n",
-       "          (resid_dropout): Dropout(p=0.1, inplace=False)\n",
-       "        )\n",
-       "        (ln_1): LayerNorm((768,), eps=1e-05, elementwise_affine=True)\n",
-       "        (mlp): MLP(\n",
-       "          (c_fc): Conv1D(nf=3072, nx=768)\n",
-       "          (c_proj): Conv1D(nf=768, nx=3072)\n",
-       "          (act): NewGELUActivation()\n",
-       "          (dropout): Dropout(p=0.1, inplace=False)\n",
-       "        )\n",
-       "        (ln_2): LayerNorm((768,), eps=1e-05, elementwise_affine=True)\n",
-       "      )\n",
-       "    )\n",
-       "  )\n",
-       "  (score): Linear(in_features=768, out_features=2, bias=False)\n",
-       ")"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model"
+    "instance_dataset = Dataset.from_dict({\n",
+    "    'input_ids': [example['input_ids']],\n",
+    "    'attention_mask': [example['attention_mask']],\n",
+    "    'labels': [example['labels']]\n",
+    "})\n",
+    "\n",
+    "unique_from_accounts = sorted(set(\n",
+    "    dataset[\"test\"][\"from_account\"]\n",
+    "))\n",
+    "label_mapping = {account: idx for idx, account in enumerate(unique_from_accounts)}\n",
+    "reverse_mapping = {idx: account for account, idx in label_mapping.items()}\n",
+    "\n",
+    "prediction = trainer.predict(instance_dataset)\n",
+    "predicted_class = prediction.predictions.argmax(axis=-1)[0]\n",
+    "\n",
+    "actual = reverse_mapping[example['labels'].item()]\n",
+    "prediction = reverse_mapping[predicted_class]\n",
+    "\n",
+    "print(example[\"text\"], actual, prediction, sep=\"\\n\\n\")"
    ]
   }
  ],

--- a/src/models/gpt_1_sequence_classification/fine_tune.ipynb
+++ b/src/models/gpt_1_sequence_classification/fine_tune.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,11 +18,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
     "from functools import partial\n",
     "from textwrap import dedent\n",
     "from typing import Dict, Literal\n",
@@ -49,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +64,7 @@
     "\n",
     "def model_init():\n",
     "    tokenizer = tokenizer_init()\n",
-    "    model = AutoModelForSequenceClassification.from_pretrained(HF_GPT_ID, num_labels=9)\n",
+    "    model = AutoModelForSequenceClassification.from_pretrained(HF_GPT_ID, num_labels=8)\n",
     "    model.resize_token_embeddings(\n",
     "        len(tokenizer), mean_resizing=False\n",
     "    )  # extend the embedding layer to handle padding\n",
@@ -79,20 +78,31 @@
     "    row = dict(row)\n",
     "    from_account = row.pop(\"from_account\")\n",
     "    formatted = dedent(\n",
-    "    f\"\"\"\n",
-    "        {json.dumps(row)}\n",
-    "    \"\"\"\n",
+    "        f\"\"\"\n",
+    "        Transaction\n",
+    "        -----------\n",
+    "        Description: {row['description']}\n",
+    "        Amount: {row['amount']}\n",
+    "        Category: {row['category']} (Source: {row['category_source']})\n",
+    "        Transaction Date: {row['transaction_date']}\n",
+    "        Day of Week: {row['day_of_week']}\n",
+    "        Card: {row['card']}\n",
+    "\n",
+    "        Question: Which account initiated this transaction?\n",
+    "        Answer:\n",
+    "        \"\"\"\n",
     "    ).strip()\n",
     "    return {\"text\": formatted, \"labels\": label_mapping[from_account]}\n",
     "\n",
     "\n",
     "def training_dataset_init(tokenizer) -> DatasetDict:\n",
-    "    dataset = load_dataset(f\"{settings.hf_user_name}/{settings.hf_dataset_repo_name}\")\n",
+    "    dataset = load_dataset(f\"{settings.hf_user_name}/{settings.hf_dataset_repo_name}\").shuffle(0)\n",
     "\n",
-    "    unique_from_accounts = set(\n",
+    "    unique_from_accounts = sorted(set(\n",
     "        dataset[\"train\"][\"from_account\"] + dataset[\"test\"][\"from_account\"]\n",
-    "    )\n",
+    "    ))\n",
     "    label_mapping = {account: idx for idx, account in enumerate(unique_from_accounts)}\n",
+    "    print(f'label_mapping: {label_mapping}')\n",
     "    format_dataset_row_partial = partial(\n",
     "        format_dataset_row,\n",
     "        label_mapping=label_mapping,\n",
@@ -102,15 +112,8 @@
     "    dataset[\"validation\"] = dataset[\"test\"].map(format_dataset_row_partial)\n",
     "    del dataset[\"test\"]\n",
     "\n",
-    "    remove_columns = [\n",
-    "        \"amount\",\n",
-    "        \"month\",\n",
-    "        \"day\",\n",
-    "        \"year\",\n",
-    "        \"vendor\",\n",
-    "        \"from_account\",\n",
-    "        \"text\"\n",
-    "    ]\n",
+    "    remove_columns = ['transaction_date', 'description', 'amount', 'category', 'category_source', 'card', 'day_of_week', 'from_account', 'text']\n",
+    "\n",
     "    dataset = dataset.map(\n",
     "        lambda batch: tokenizer(batch[\"text\"]),\n",
     "        batched=True,\n",
@@ -129,32 +132,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a33dae6962e54ceea20df129f64316bc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/743 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "label_mapping: {'Assets:Discover:Furniture': 0, 'Assets:Discover:FutureWants': 1, 'Assets:Discover:Main:Needs:Gas': 2, 'Assets:Discover:Main:Needs:Groceries': 3, 'Assets:Discover:Main:Needs:Monthly': 4, 'Assets:Discover:Main:Needs:Other': 5, 'Assets:Discover:Main:Wants:Monthly': 6, 'Assets:Discover:Main:Wants:Other': 7}\n"
+     ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2a71802887f748d6b5dc1ad8efabcce4",
+       "model_id": "b71affb4568a4e70a12982f814a24639",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/764 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -163,12 +159,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "41dd4feaf0f643c1b9a648535c692740",
+       "model_id": "5906819aff0a44faa4699ceeab947b88",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/743 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/193 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -177,12 +173,26 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a946f26ec0d841a39830f24e0e5f265a",
+       "model_id": "aaf61140800f4ac78fdbcc791ea76f2d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/764 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2e4c4e360bc34a048be67a3e33a8f88a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/193 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -192,7 +202,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:05:52,127] A new study created in memory with name: no-name-d9bc123a-871e-4dee-b731-e4b9d5e1ae89\n"
+      "[I 2025-03-23 16:25:03,535] A new study created in memory with name: no-name-f30295bb-3aa7-46c9-8207-d17380973048\n"
      ]
     },
     {
@@ -202,7 +212,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [12/12 00:03, Epoch 1/1]\n",
+       "      [12/12 00:06, Epoch 1/1]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -215,8 +225,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>1.615400</td>\n",
-       "      <td>1.361363</td>\n",
+       "      <td>1.761100</td>\n",
+       "      <td>1.525469</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -232,7 +242,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:05:56,470] Trial 0 finished with value: 1.3613629341125488 and parameters: {'learning_rate': 2.6385847657862185e-05}. Best is trial 0 with value: 1.3613629341125488.\n"
+      "[I 2025-03-23 16:25:11,736] Trial 0 finished with value: 1.525469422340393 and parameters: {'learning_rate': 1.2431684939654512e-05}. Best is trial 0 with value: 1.525469422340393.\n"
      ]
     },
     {
@@ -242,7 +252,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [12/12 00:02, Epoch 1/1]\n",
+       "      [12/12 00:05, Epoch 1/1]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -255,8 +265,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>1.706200</td>\n",
-       "      <td>1.216077</td>\n",
+       "      <td>1.715100</td>\n",
+       "      <td>1.504723</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -272,7 +282,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:06:08,551] Trial 1 finished with value: 1.2160768508911133 and parameters: {'learning_rate': 0.00017654440874111848}. Best is trial 1 with value: 1.2160768508911133.\n"
+      "[I 2025-03-23 16:25:19,079] Trial 1 finished with value: 1.5047225952148438 and parameters: {'learning_rate': 0.000283964877953884}. Best is trial 1 with value: 1.5047225952148438.\n"
      ]
     },
     {
@@ -282,7 +292,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [12/12 00:02, Epoch 1/1]\n",
+       "      [12/12 00:06, Epoch 1/1]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -295,8 +305,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>1.570800</td>\n",
-       "      <td>1.026987</td>\n",
+       "      <td>1.715900</td>\n",
+       "      <td>1.515454</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -312,7 +322,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:06:17,255] Trial 2 finished with value: 1.0269871950149536 and parameters: {'learning_rate': 0.00011761323975949382}. Best is trial 2 with value: 1.0269871950149536.\n"
+      "[I 2025-03-23 16:25:26,888] Trial 2 finished with value: 1.5154544115066528 and parameters: {'learning_rate': 0.0002713673779161299}. Best is trial 1 with value: 1.5047225952148438.\n"
      ]
     },
     {
@@ -322,7 +332,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [12/12 00:02, Epoch 1/1]\n",
+       "      [12/12 00:06, Epoch 1/1]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -335,8 +345,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>1.715400</td>\n",
-       "      <td>1.560079</td>\n",
+       "      <td>1.623200</td>\n",
+       "      <td>1.521107</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -352,7 +362,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:06:21,264] Trial 3 finished with value: 1.5600794553756714 and parameters: {'learning_rate': 8.25688321383896e-06}. Best is trial 2 with value: 1.0269871950149536.\n"
+      "[I 2025-03-23 16:25:34,853] Trial 3 finished with value: 1.5211067199707031 and parameters: {'learning_rate': 8.985463055747293e-05}. Best is trial 1 with value: 1.5047225952148438.\n"
      ]
     },
     {
@@ -362,7 +372,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [12/12 00:02, Epoch 1/1]\n",
+       "      [12/12 00:06, Epoch 1/1]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -375,8 +385,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>2.050000</td>\n",
-       "      <td>2.010101</td>\n",
+       "      <td>1.713100</td>\n",
+       "      <td>1.497422</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -392,16 +402,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[I 2025-03-19 21:06:25,222] Trial 4 finished with value: 2.010101079940796 and parameters: {'learning_rate': 2.956816030763976e-07}. Best is trial 2 with value: 1.0269871950149536.\n"
+      "[I 2025-03-23 16:25:42,911] Trial 4 finished with value: 1.4974219799041748 and parameters: {'learning_rate': 1.5703603902088657e-05}. Best is trial 4 with value: 1.4974219799041748.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "BestRun(run_id='2', objective=1.0269871950149536, hyperparameters={'learning_rate': 0.00011761323975949382}, run_summary=None)"
+       "BestRun(run_id='4', objective=1.4974219799041748, hyperparameters={'learning_rate': 1.5703603902088657e-05}, run_summary=None)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -434,7 +444,7 @@
     "\n",
     "best_run = trainer.hyperparameter_search(\n",
     "    hp_space=lambda trial: {\n",
-    "        \"learning_rate\": trial.suggest_float(\"learning_rate\", 1e-7, 1e-3, log=True)\n",
+    "        \"learning_rate\": trial.suggest_float(\"learning_rate\", 1e-5, 5e-4, log=True)\n",
     "    },\n",
     "    n_trials=5,\n",
     "    direction=\"minimize\",\n",
@@ -452,45 +462,98 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 1.5062, 'grad_norm': 3.570878028869629, 'learning_rate': 0.0001097723571088609, 'epoch': 1.0}\n",
-      "{'eval_loss': 0.8068403005599976, 'eval_runtime': 0.1887, 'eval_samples_per_second': 991.08, 'eval_steps_per_second': 15.9, 'epoch': 1.0}\n",
-      "{'loss': 0.7222, 'grad_norm': 3.5703277587890625, 'learning_rate': 0.00010193147445822798, 'epoch': 2.0}\n",
-      "{'eval_loss': 0.6196367740631104, 'eval_runtime': 0.1882, 'eval_samples_per_second': 993.422, 'eval_steps_per_second': 15.937, 'epoch': 2.0}\n",
-      "{'loss': 0.4747, 'grad_norm': 3.3774116039276123, 'learning_rate': 9.409059180759506e-05, 'epoch': 3.0}\n",
-      "{'eval_loss': 0.6139162182807922, 'eval_runtime': 0.1907, 'eval_samples_per_second': 980.464, 'eval_steps_per_second': 15.729, 'epoch': 3.0}\n",
-      "{'loss': 0.487, 'grad_norm': 2.792229413986206, 'learning_rate': 8.624970915696212e-05, 'epoch': 4.0}\n",
-      "{'eval_loss': 0.6617082953453064, 'eval_runtime': 0.1935, 'eval_samples_per_second': 966.532, 'eval_steps_per_second': 15.506, 'epoch': 4.0}\n",
-      "{'loss': 0.2917, 'grad_norm': 6.448467254638672, 'learning_rate': 7.840882650632921e-05, 'epoch': 5.0}\n",
-      "{'eval_loss': 0.7250003814697266, 'eval_runtime': 0.192, 'eval_samples_per_second': 974.051, 'eval_steps_per_second': 15.626, 'epoch': 5.0}\n",
-      "{'loss': 0.2572, 'grad_norm': 4.069180965423584, 'learning_rate': 7.05679438556963e-05, 'epoch': 6.0}\n",
-      "{'eval_loss': 0.6277047395706177, 'eval_runtime': 0.2124, 'eval_samples_per_second': 880.357, 'eval_steps_per_second': 14.123, 'epoch': 6.0}\n",
-      "{'train_runtime': 24.5994, 'train_samples_per_second': 453.059, 'train_steps_per_second': 7.317, 'train_loss': 0.6231741938326094, 'epoch': 6.0}\n"
+      "label_mapping: {'Assets:Discover:Furniture': 0, 'Assets:Discover:FutureWants': 1, 'Assets:Discover:Main:Needs:Gas': 2, 'Assets:Discover:Main:Needs:Groceries': 3, 'Assets:Discover:Main:Needs:Monthly': 4, 'Assets:Discover:Main:Needs:Other': 5, 'Assets:Discover:Main:Wants:Monthly': 6, 'Assets:Discover:Main:Wants:Other': 7}\n"
      ]
     },
     {
      "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='96' max='180' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [ 96/180 01:02 < 00:56, 1.50 it/s, Epoch 8/15]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>1.666100</td>\n",
+       "      <td>1.457538</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>1.369600</td>\n",
+       "      <td>1.002303</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>0.697700</td>\n",
+       "      <td>0.556376</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>0.375100</td>\n",
+       "      <td>0.457325</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>0.252800</td>\n",
+       "      <td>0.380322</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>6</td>\n",
+       "      <td>0.150300</td>\n",
+       "      <td>0.269912</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>7</td>\n",
+       "      <td>0.086300</td>\n",
+       "      <td>0.288816</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>8</td>\n",
+       "      <td>0.054700</td>\n",
+       "      <td>0.329497</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
       "text/plain": [
-       "TrainOutput(global_step=72, training_loss=0.6231741938326094, metrics={'train_runtime': 24.5994, 'train_samples_per_second': 453.059, 'train_steps_per_second': 7.317, 'train_loss': 0.6231741938326094, 'epoch': 6.0})"
+       "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 9,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TrainOutput(global_step=96, training_loss=0.5815815708289543, metrics={'train_runtime': 63.3679, 'train_samples_per_second': 180.849, 'train_steps_per_second': 2.841, 'total_flos': 284921734496256.0, 'train_loss': 0.5815815708289543, 'epoch': 8.0})"
+      ]
+     },
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#  objective=1.50540292263031, hyperparameters={'learning_rate': 8.232913715704246e-05} with prompting\n",
-    "# BestRun(run_id='2', objective=1.0269871950149536, hyperparameters={'learning_rate': 0.00011761323975949382}, run_summary=None) without prompting\n",
-    "\n",
     "n_epochs = 15  # will likely stop early\n",
-    "best_learning_rate = 0.00011761323975949382\n",
+    "best_learning_rate = 5.38312346311055e-05\n",
     "\n",
     "tokenizer = tokenizer_init()\n",
     "dataset = training_dataset_init(tokenizer)\n",
@@ -510,6 +573,7 @@
     "    metric_for_best_model=\"eval_loss\",\n",
     "    greater_is_better=False,\n",
     "    load_best_model_at_end=True,\n",
+    "    disable_tqdm=False,\n",
     ")\n",
     "\n",
     "trainer = Trainer(\n",
@@ -518,7 +582,7 @@
     "    data_collator=DataCollatorWithPadding(tokenizer=tokenizer),\n",
     "    train_dataset=dataset[\"train\"],\n",
     "    eval_dataset=dataset[\"validation\"],\n",
-    "    callbacks=[EarlyStoppingCallback(early_stopping_patience=3)],\n",
+    "    callbacks=[EarlyStoppingCallback(early_stopping_patience=2)],\n",
     ")\n",
     "\n",
     "trainer.train()"
@@ -526,13 +590,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e743bfce8603473e8316932547cfd529",
+       "model_id": "58420f580dcf423c8139b7ed720ed4cc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -546,16 +610,16 @@
     {
      "data": {
       "text/plain": [
-       "CommitInfo(commit_url='https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune/commit/d7de8e056288fe9546ebf1b2106d113d9db26f9a', commit_message='End of training', commit_description='', oid='d7de8e056288fe9546ebf1b2106d113d9db26f9a', pr_url=None, repo_url=RepoUrl('https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune', endpoint='https://huggingface.co', repo_type='model', repo_id='jacob-danner/gpt_1_sequence_classification_finetune'), pr_revision=None, pr_num=None)"
+       "CommitInfo(commit_url='https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune/commit/ee6d2713c0019a163e8e90b46b603934e66b2f93', commit_message='feat: train with sorted label to make training behavior reproducible at evaluation time', commit_description='', oid='ee6d2713c0019a163e8e90b46b603934e66b2f93', pr_url=None, repo_url=RepoUrl('https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune', endpoint='https://huggingface.co', repo_type='model', repo_id='jacob-danner/gpt_1_sequence_classification_finetune'), pr_revision=None, pr_num=None)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "trainer.push_to_hub()"
+    "trainer.push_to_hub(commit_message=\"feat: train with sorted label to make training behavior reproducible at evaluation time\")"
    ]
   }
  ],

--- a/src/models/gpt_1_sequence_classification/fine_tune.ipynb
+++ b/src/models/gpt_1_sequence_classification/fine_tune.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append(\n",
+    "    os.path.abspath(\n",
+    "        os.path.join(os.path.dirname(os.path.abspath(\"__file__\")), \"../../..\")\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from functools import partial\n",
+    "from textwrap import dedent\n",
+    "from typing import Dict, Literal\n",
+    "\n",
+    "from datasets import DatasetDict, load_dataset\n",
+    "from transformers import (\n",
+    "    AutoModelForSequenceClassification,\n",
+    "    AutoTokenizer,\n",
+    "    DataCollatorWithPadding,\n",
+    "    EarlyStoppingCallback,\n",
+    "    Trainer,\n",
+    "    TrainingArguments,\n",
+    ")\n",
+    "\n",
+    "from src.shared.config import settings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HF_GPT_ID = \"openai-gpt\"\n",
+    "\n",
+    "def tokenizer_init():\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(HF_GPT_ID)\n",
+    "    tokenizer.add_special_tokens(\n",
+    "        {\"pad_token\": \"<pad>\"}\n",
+    "    )  # gpt-1 tokenizer lacks this by default\n",
+    "    return tokenizer\n",
+    "\n",
+    "\n",
+    "def model_init():\n",
+    "    tokenizer = tokenizer_init()\n",
+    "    model = AutoModelForSequenceClassification.from_pretrained(HF_GPT_ID, num_labels=9)\n",
+    "    model.resize_token_embeddings(\n",
+    "        len(tokenizer), mean_resizing=False\n",
+    "    )  # extend the embedding layer to handle padding\n",
+    "    model.config.pad_token_id = tokenizer.pad_token_id\n",
+    "    return model.to(settings.device)\n",
+    "\n",
+    "\n",
+    "def format_dataset_row(\n",
+    "    row, label_mapping: Dict[str, int]\n",
+    ") -> Dict[Literal[\"text\"], str]:\n",
+    "    row = dict(row)\n",
+    "    from_account = row.pop(\"from_account\")\n",
+    "    formatted = dedent(\n",
+    "    f\"\"\"\n",
+    "        {json.dumps(row)}\n",
+    "    \"\"\"\n",
+    "    ).strip()\n",
+    "    return {\"text\": formatted, \"labels\": label_mapping[from_account]}\n",
+    "\n",
+    "\n",
+    "def training_dataset_init(tokenizer) -> DatasetDict:\n",
+    "    dataset = load_dataset(f\"{settings.hf_user_name}/{settings.hf_dataset_repo_name}\")\n",
+    "\n",
+    "    unique_from_accounts = set(\n",
+    "        dataset[\"train\"][\"from_account\"] + dataset[\"test\"][\"from_account\"]\n",
+    "    )\n",
+    "    label_mapping = {account: idx for idx, account in enumerate(unique_from_accounts)}\n",
+    "    format_dataset_row_partial = partial(\n",
+    "        format_dataset_row,\n",
+    "        label_mapping=label_mapping,\n",
+    "    )\n",
+    "\n",
+    "    dataset[\"train\"] = dataset[\"train\"].map(format_dataset_row_partial)\n",
+    "    dataset[\"validation\"] = dataset[\"test\"].map(format_dataset_row_partial)\n",
+    "    del dataset[\"test\"]\n",
+    "\n",
+    "    remove_columns = [\n",
+    "        \"amount\",\n",
+    "        \"month\",\n",
+    "        \"day\",\n",
+    "        \"year\",\n",
+    "        \"vendor\",\n",
+    "        \"from_account\",\n",
+    "        \"text\"\n",
+    "    ]\n",
+    "    dataset = dataset.map(\n",
+    "        lambda batch: tokenizer(batch[\"text\"]),\n",
+    "        batched=True,\n",
+    "        remove_columns=remove_columns,\n",
+    "    )\n",
+    "    dataset.set_format(\"pt\")\n",
+    "    return dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Identify Best Learning Rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a33dae6962e54ceea20df129f64316bc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/743 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a71802887f748d6b5dc1ad8efabcce4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "41dd4feaf0f643c1b9a648535c692740",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/743 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a946f26ec0d841a39830f24e0e5f265a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/187 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:05:52,127] A new study created in memory with name: no-name-d9bc123a-871e-4dee-b731-e4b9d5e1ae89\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [12/12 00:03, Epoch 1/1]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>1.615400</td>\n",
+       "      <td>1.361363</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:05:56,470] Trial 0 finished with value: 1.3613629341125488 and parameters: {'learning_rate': 2.6385847657862185e-05}. Best is trial 0 with value: 1.3613629341125488.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [12/12 00:02, Epoch 1/1]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>1.706200</td>\n",
+       "      <td>1.216077</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:06:08,551] Trial 1 finished with value: 1.2160768508911133 and parameters: {'learning_rate': 0.00017654440874111848}. Best is trial 1 with value: 1.2160768508911133.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [12/12 00:02, Epoch 1/1]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>1.570800</td>\n",
+       "      <td>1.026987</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:06:17,255] Trial 2 finished with value: 1.0269871950149536 and parameters: {'learning_rate': 0.00011761323975949382}. Best is trial 2 with value: 1.0269871950149536.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [12/12 00:02, Epoch 1/1]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>1.715400</td>\n",
+       "      <td>1.560079</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:06:21,264] Trial 3 finished with value: 1.5600794553756714 and parameters: {'learning_rate': 8.25688321383896e-06}. Best is trial 2 with value: 1.0269871950149536.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='12' max='12' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [12/12 00:02, Epoch 1/1]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Epoch</th>\n",
+       "      <th>Training Loss</th>\n",
+       "      <th>Validation Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>2.050000</td>\n",
+       "      <td>2.010101</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2025-03-19 21:06:25,222] Trial 4 finished with value: 2.010101079940796 and parameters: {'learning_rate': 2.956816030763976e-07}. Best is trial 2 with value: 1.0269871950149536.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BestRun(run_id='2', objective=1.0269871950149536, hyperparameters={'learning_rate': 0.00011761323975949382}, run_summary=None)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = training_dataset_init(tokenizer_init())\n",
+    "\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"/tmp/lr_search\",\n",
+    "    num_train_epochs=1,\n",
+    "    per_device_train_batch_size=64,\n",
+    "    per_device_eval_batch_size=64,\n",
+    "    weight_decay=0.01,\n",
+    "    eval_strategy=\"epoch\",\n",
+    "    logging_strategy=\"epoch\",\n",
+    "    disable_tqdm=False,\n",
+    "    push_to_hub=False,\n",
+    "    log_level=\"error\",\n",
+    "    save_strategy=\"no\",\n",
+    "    report_to=\"none\",\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model_init=model_init,\n",
+    "    args=training_args,\n",
+    "    data_collator=DataCollatorWithPadding(tokenizer=tokenizer_init()),\n",
+    "    train_dataset=dataset[\"train\"],\n",
+    "    eval_dataset=dataset[\"validation\"],\n",
+    ")\n",
+    "\n",
+    "best_run = trainer.hyperparameter_search(\n",
+    "    hp_space=lambda trial: {\n",
+    "        \"learning_rate\": trial.suggest_float(\"learning_rate\", 1e-7, 1e-3, log=True)\n",
+    "    },\n",
+    "    n_trials=5,\n",
+    "    direction=\"minimize\",\n",
+    ")\n",
+    "\n",
+    "best_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'loss': 1.5062, 'grad_norm': 3.570878028869629, 'learning_rate': 0.0001097723571088609, 'epoch': 1.0}\n",
+      "{'eval_loss': 0.8068403005599976, 'eval_runtime': 0.1887, 'eval_samples_per_second': 991.08, 'eval_steps_per_second': 15.9, 'epoch': 1.0}\n",
+      "{'loss': 0.7222, 'grad_norm': 3.5703277587890625, 'learning_rate': 0.00010193147445822798, 'epoch': 2.0}\n",
+      "{'eval_loss': 0.6196367740631104, 'eval_runtime': 0.1882, 'eval_samples_per_second': 993.422, 'eval_steps_per_second': 15.937, 'epoch': 2.0}\n",
+      "{'loss': 0.4747, 'grad_norm': 3.3774116039276123, 'learning_rate': 9.409059180759506e-05, 'epoch': 3.0}\n",
+      "{'eval_loss': 0.6139162182807922, 'eval_runtime': 0.1907, 'eval_samples_per_second': 980.464, 'eval_steps_per_second': 15.729, 'epoch': 3.0}\n",
+      "{'loss': 0.487, 'grad_norm': 2.792229413986206, 'learning_rate': 8.624970915696212e-05, 'epoch': 4.0}\n",
+      "{'eval_loss': 0.6617082953453064, 'eval_runtime': 0.1935, 'eval_samples_per_second': 966.532, 'eval_steps_per_second': 15.506, 'epoch': 4.0}\n",
+      "{'loss': 0.2917, 'grad_norm': 6.448467254638672, 'learning_rate': 7.840882650632921e-05, 'epoch': 5.0}\n",
+      "{'eval_loss': 0.7250003814697266, 'eval_runtime': 0.192, 'eval_samples_per_second': 974.051, 'eval_steps_per_second': 15.626, 'epoch': 5.0}\n",
+      "{'loss': 0.2572, 'grad_norm': 4.069180965423584, 'learning_rate': 7.05679438556963e-05, 'epoch': 6.0}\n",
+      "{'eval_loss': 0.6277047395706177, 'eval_runtime': 0.2124, 'eval_samples_per_second': 880.357, 'eval_steps_per_second': 14.123, 'epoch': 6.0}\n",
+      "{'train_runtime': 24.5994, 'train_samples_per_second': 453.059, 'train_steps_per_second': 7.317, 'train_loss': 0.6231741938326094, 'epoch': 6.0}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TrainOutput(global_step=72, training_loss=0.6231741938326094, metrics={'train_runtime': 24.5994, 'train_samples_per_second': 453.059, 'train_steps_per_second': 7.317, 'train_loss': 0.6231741938326094, 'epoch': 6.0})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#  objective=1.50540292263031, hyperparameters={'learning_rate': 8.232913715704246e-05} with prompting\n",
+    "# BestRun(run_id='2', objective=1.0269871950149536, hyperparameters={'learning_rate': 0.00011761323975949382}, run_summary=None) without prompting\n",
+    "\n",
+    "n_epochs = 15  # will likely stop early\n",
+    "best_learning_rate = 0.00011761323975949382\n",
+    "\n",
+    "tokenizer = tokenizer_init()\n",
+    "dataset = training_dataset_init(tokenizer)\n",
+    "\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"/tmp/gpt_1_sequence_classification\",\n",
+    "    per_device_train_batch_size=64,\n",
+    "    per_device_eval_batch_size=64,\n",
+    "    num_train_epochs=n_epochs,\n",
+    "    learning_rate=best_learning_rate,\n",
+    "    weight_decay=0.01,\n",
+    "    eval_strategy=\"epoch\",\n",
+    "    logging_strategy=\"epoch\",\n",
+    "    save_strategy=\"epoch\",\n",
+    "    push_to_hub=True,\n",
+    "    hub_model_id=f\"{settings.hf_user_name}/{settings.gpt_1_sequence_classification}\",\n",
+    "    metric_for_best_model=\"eval_loss\",\n",
+    "    greater_is_better=False,\n",
+    "    load_best_model_at_end=True,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model_init=model_init,\n",
+    "    args=training_args,\n",
+    "    data_collator=DataCollatorWithPadding(tokenizer=tokenizer),\n",
+    "    train_dataset=dataset[\"train\"],\n",
+    "    eval_dataset=dataset[\"validation\"],\n",
+    "    callbacks=[EarlyStoppingCallback(early_stopping_patience=3)],\n",
+    ")\n",
+    "\n",
+    "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e743bfce8603473e8316932547cfd529",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/466M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "CommitInfo(commit_url='https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune/commit/d7de8e056288fe9546ebf1b2106d113d9db26f9a', commit_message='End of training', commit_description='', oid='d7de8e056288fe9546ebf1b2106d113d9db26f9a', pr_url=None, repo_url=RepoUrl('https://huggingface.co/jacob-danner/gpt_1_sequence_classification_finetune', endpoint='https://huggingface.co', repo_type='model', repo_id='jacob-danner/gpt_1_sequence_classification_finetune'), pr_revision=None, pr_num=None)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.push_to_hub()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     hf_user_name: str
     hf_dataset_repo_name: str
     gpt_1_causal_finetune: str
+    gpt_1_sequence_classification: str
     device: str
 
     class Config:


### PR DESCRIPTION
Giving gpt-1 a classification head seemed to be much more successful than normal autoregressive modeling. This probably means that the account hierarchy might be challenging for autoregressive modeling.

Imagine judging between `Assets:Discover:Main:Needs:Other` and `Assets:Discover:Furniture`: at `Assets:Discover:` `Main` might have slightly higher probability than `Furniture`, but if you were to unravel the conditional probability in a beam search way, maybe `Furniture` is the more likely candidate overall. If you commit to `Main` as the next token, there is no backtracking.

A classification head removes this problem entirely - effectively scoring each category at once.